### PR TITLE
Improve language toggle, visuals, pause and persistence

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -744,6 +744,10 @@ canvas {
     transform: scale(1.1);
 }
 
+#pause-btn {
+    margin-left: 6px;
+}
+
 /* PARTİKÜL SİSTEMİ */
 .particle {
     position: absolute;

--- a/index.html
+++ b/index.html
@@ -60,8 +60,11 @@
             <button class="sound-btn" id="sound-toggle">
                 <i class="fas fa-volume-up"></i>
             </button>
-            <button class="sound-btn" id="pause-toggle" title="Pause/Settings">
+            <button class="sound-btn" id="pause-btn" title="Pause">
                 <i class="fas fa-pause"></i>
+            </button>
+            <button class="sound-btn" id="settings-toggle" title="Settings">
+                <i class="fas fa-cog"></i>
             </button>
         </div>
 
@@ -165,6 +168,7 @@
             <p data-lang="gameFeatures"><strong>YENİ:</strong> Kontrol ışığı sistemi ile artık mikroskobik hataları da tespit edebilirsin! Bazı hatalar sadece özel ışık altında görünür.</p>
             <p data-lang="gameStory"><strong>Hikaye:</strong> Global İçecek A.Ş.'de yeni başlayan bir kalite kontrol uzmanısın. 40 bölümlük epik bir serüvende fabrikayı sabotajdan koruman gerekiyor!</p>
             <button id="start-button" data-lang="startGame">MACERAYA BAŞLA</button>
+            <button id="continue-button" data-lang="continueGame" class="hidden">Continue</button>
         </div>
 
         <!-- Oyun Bitti Ekranı -->

--- a/js/config.js
+++ b/js/config.js
@@ -3,7 +3,9 @@
 
 const GameConfig = {
     version: "2.0.0",
-    
+    // active language shared across modules
+    currentLang: localStorage.getItem('qc_currentLang') || 'en',
+
     // Oyun ayarları
     maxWidth: 1000,
     maxHeight: 600,

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,41 @@
 // KALITE KONTROL SIMÜLATÖRÜ PRO - ANA BAŞLATICI
 // Sürüm: v2.0.0
 
+// basit kayıt yöneticisi
+class GameSaveManager {
+    constructor() {
+        this.key = 'qc_save_v1';
+        this.version = 1;
+        this.lastSave = 0;
+    }
+
+    save(state) {
+        const now = Date.now();
+        if (now - this.lastSave < 2000) return; // throttle
+        this.lastSave = now;
+        const data = { ...state, version: this.version, timestamp: now };
+        localStorage.setItem(this.key, JSON.stringify(data));
+    }
+
+    load() {
+        try {
+            const raw = localStorage.getItem(this.key);
+            if (!raw) return null;
+            const data = JSON.parse(raw);
+            if (data.version !== this.version) return null;
+            return data;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    clear() {
+        localStorage.removeItem(this.key);
+    }
+}
+
+window.GameSaveManager = new GameSaveManager();
+
 class AppLoader {
     constructor() {
         this.game = null;
@@ -59,11 +94,23 @@ class AppLoader {
         
         // Ana oyun nesnesini oluştur
         this.game = new Game();
-        
+
         // Başlangıç ekranını göster
         const startScreen = document.getElementById('start-screen');
         if (startScreen) {
             startScreen.classList.remove('hidden');
+
+            const save = window.GameSaveManager.load();
+            const continueBtn = document.getElementById('continue-button');
+            if (save && continueBtn) {
+                continueBtn.classList.remove('hidden');
+                continueBtn.addEventListener('click', () => {
+                    this.game.loadState(save);
+                    this.game.uiManager.hideStartScreen();
+                    this.game.startGame();
+                    this.game.combo = save.combo || 0;
+                }, { once: true });
+            }
         }
         
         console.log('Oyun başarıyla yüklendi ve hazır!');

--- a/js/settings.js
+++ b/js/settings.js
@@ -5,7 +5,7 @@ class SettingsManager {
             sound: { master: 1, effects: 1 },
             graphics: { videoBackground: true, quality: 'high' },
             accessibility: { colorFilter: 'none' },
-            language: localStorage.getItem('gameLanguage') || 'en'
+            language: localStorage.getItem('qc_currentLang') || 'en'
         };
         this.state = JSON.parse(localStorage.getItem('qc_settings') || 'null') || this.defaults;
         this.persist();

--- a/js/ui.js
+++ b/js/ui.js
@@ -37,6 +37,8 @@ class UIManager {
             slowmoBtn: document.getElementById('slowmo-btn'),
             // controlLightBtn artık yok - sürekli aktif
             soundToggle: document.getElementById('sound-toggle'),
+            pauseBtn: document.getElementById('pause-btn'),
+            settingsBtn: document.getElementById('settings-toggle'),
             mobileLeftBtn: document.getElementById('mobile-left'),
             mobileRightBtn: document.getElementById('mobile-right'),
             langTrBtn: document.getElementById('lang-tr'),
@@ -59,7 +61,7 @@ class UIManager {
         }
 
         // Dil değişikliği olayını dinle
-        document.addEventListener('languageChanged', () => {
+        EventBus.subscribe('languageChanged', () => {
             this.updateAllLanguageTexts();
         });
 
@@ -69,7 +71,7 @@ class UIManager {
     }
 
     setupSettingsPanel() {
-        const pauseBtn = document.getElementById('pause-toggle');
+        const settingsBtn = this.elements.settingsBtn;
         const panel = document.getElementById('settings-panel');
         const closeBtn = document.getElementById('settings-close');
         const volM = document.getElementById('volume-master');
@@ -78,7 +80,7 @@ class UIManager {
         const qual = document.getElementById('graphics-quality');
         const filt = document.getElementById('color-filter');
 
-        if (!pauseBtn || !panel) return;
+        if (!settingsBtn || !panel) return;
 
         // init values
         volM && (volM.value = window.SettingsManager.get('sound.master'));
@@ -87,7 +89,7 @@ class UIManager {
         qual && (qual.value = window.SettingsManager.get('graphics.quality'));
         filt && (filt.value = window.SettingsManager.get('accessibility.colorFilter'));
 
-        pauseBtn.addEventListener('click', () => {
+        settingsBtn.addEventListener('click', () => {
             panel.classList.toggle('show');
         });
         closeBtn && closeBtn.addEventListener('click', () => panel.classList.remove('show'));
@@ -427,6 +429,20 @@ class SoundManager {
     
     toggle() {
         this.enabled = !this.enabled;
+        const icon = document.querySelector('#sound-toggle i');
+        if (icon) {
+            icon.className = this.enabled ? 'fas fa-volume-up' : 'fas fa-volume-mute';
+        }
+    }
+
+    // temporarily mute while preserving previous state
+    mute(state) {
+        if (state) {
+            this.prevEnabled = this.enabled;
+            this.enabled = false;
+        } else {
+            this.enabled = this.prevEnabled !== undefined ? this.prevEnabled : true;
+        }
         const icon = document.querySelector('#sound-toggle i');
         if (icon) {
             icon.className = this.enabled ? 'fas fa-volume-up' : 'fas fa-volume-mute';


### PR DESCRIPTION
## Summary
- Centralize language preference with debounced EventBus updates and config persistence
- Add combo-synced glow behind the inspection zone for visual feedback
- Introduce GameEngine with pause/resume, UI button and audio muting
- Implement versioned save system with continue option at start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68951c6917b083329148f214eb65f2c9